### PR TITLE
Fix import path for encryption tests

### DIFF
--- a/quantum L.L.M.A/tests.py
+++ b/quantum L.L.M.A/tests.py
@@ -1,13 +1,24 @@
 # tests/test_encryption.py
 
+import os
+import sys
 import unittest
-from security.encryption import EncryptionManager
+
+# Add the path to the encryption module that resides in
+# "quantum A.I. General Agent system prototype/encryption.py"
+MODULE_DIR = os.path.join(os.path.dirname(__file__), '..', 'quantum A.I. General Agent system prototype')
+if MODULE_DIR not in sys.path:
+    sys.path.insert(0, MODULE_DIR)
+
+from encryption import EncryptionManager
 
 class TestEncryptionManager(unittest.TestCase):
     def test_encryption_decryption(self):
         manager = EncryptionManager()
         plaintext = "Test message"
         encrypted = manager.encrypt(plaintext)
+        # Ensure that the encrypted data differs from the original plaintext
+        self.assertNotEqual(encrypted, plaintext)
         decrypted = manager.decrypt(encrypted)
         self.assertEqual(plaintext, decrypted)
 


### PR DESCRIPTION
## Summary
- fix tests import path by adding repo directory to `sys.path`
- assert that encrypted data differs from plaintext

## Testing
- `pip install cryptography`
- `python3 -m unittest discover -s 'quantum L.L.M.A' -p tests.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7af03b2c8321b626788c0c50888c