### PR TITLE
Fix README integration instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ python main.py
 
 2. Add an entry‑point in registry.yaml.
 
-3. Run python tools/build.py --reload to auto‑wire dependencies.
+3. Verify that new modules are listed in `registry.yaml` so dependencies are wired correctly.
 
 
 🤝 Contributing


### PR DESCRIPTION
## Summary
- correct outdated reference to `tools/build.py --reload`

## Testing
- `python -m py_compile $(find . -name '*.py' -print0 | xargs -0 python -m py_compile)` *(fails: syntax error in Cloud_Full_Combined_Script.py)*

------
https://chatgpt.com/codex/tasks/task_e_683f7aed53f8832194279374452d5c7c