### PR TITLE
Add pytest runner and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,13 @@ Made with 💙 by Brion tech. and The Team — forging the next epoch of quantum
 
 
 Core Devs - Brion, Charlie, Sora and Kairi.
+
+## Running Tests
+
+Use the `run_tests.sh` script to execute the test suite. The script runs `pytest` and stores the results in `pytest.log` and `pytest_results.xml` so they can be tracked under version control.
+
+```bash
+./run_tests.sh
+```
+
+`pytest.log` captures the console output while `pytest_results.xml` stores the results in JUnit format.

--- a/pytest.log
+++ b/pytest.log
@@ -1,0 +1,11 @@
+============================= test session starts ==============================
+platform linux -- Python 3.11.12, pytest-8.3.5, pluggy-1.6.0 -- /root/.pyenv/versions/3.11.12/bin/python3.11
+cachedir: .pytest_cache
+rootdir: /workspace/Quantum-A.I.-Large-Language-Model-Agent-L.L.M.A-
+plugins: anyio-4.9.0
+collecting ... collected 1 item
+
+quantum L.L.M.A/tests.py::TestEncryptionManager::test_encryption_decryption PASSED [100%]
+
+- generated xml file: /workspace/Quantum-A.I.-Large-Language-Model-Agent-L.L.M.A-/pytest_results.xml -
+============================== 1 passed in 0.04s ===============================

--- a/pytest_results.xml
+++ b/pytest_results.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="0.045" timestamp="2025-06-04T00:55:01.550611+00:00" hostname="3d92250ef615"><testcase classname="quantum L.L.M.A.tests.TestEncryptionManager" name="test_encryption_decryption" time="0.002" /></testsuite></testsuites>

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Run the test suite and store results.
+set -e
+pytest 'quantum L.L.M.A/tests.py' -vv --junitxml=pytest_results.xml 2>&1 | tee pytest.log


### PR DESCRIPTION
## Summary
- add `run_tests.sh` for running pytest and storing logs
- store generated `pytest.log` and `pytest_results.xml`
- document how to run the tests in the README

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f9902a82c8321a0eae0c1460fea1d